### PR TITLE
1.1

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -7,7 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
     if (toggle) {
         refreshToggle(isEnabled());
 
-        toggle.onclick = function(event) {
+        toggle.onmousedown = function(event) {
             if (isEnabled()) {
                 setEnabled(false);
                 refreshToggle(false);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create load test scripts to run in Loadster Workbench.",
-  "version": "1.0",
+  "version": "1.1",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
This fixes a usability issue with the big toggle switch. Some users tried to drag it instead of clicking it, and if they dragged it too far, the click event didn't register.