### PR TITLE
Create a tab from the provided URL

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -145,7 +145,9 @@ function indicateRecording(tick) {
         chrome.tabs.get(id, (tab) => {
             if (tab.status === 'complete' && titles[tab.id]) {
                 const title = `${((tick % 2 === 0) ? iconA : iconB)} ${titles[tab.id]}`;
-                const code = `document.title = '${title}'`;
+                const escaped = title.replace('\'', '\\\'');
+                const code = `document.title = '${escaped}'`;
+
                 chrome.tabs.executeScript(id, { code });
             }
         });

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,6 @@
     "scripts": ["js/background.js"]
   },
   "permissions": [
-    "tabs",
     "activeTab",
     "storage",
     "webRequest",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create load test scripts to run in Loadster.",
-  "version": "2.3",
+  "version": "2.4",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",
@@ -18,6 +18,7 @@
     "scripts": ["js/background.js"]
   },
   "permissions": [
+    "tabs",
     "activeTab",
     "storage",
     "webRequest",


### PR DESCRIPTION
@azhawkes 
Please note, this  update relates and requires [https://github.com/loadster/loadster-dashboard/pull/44](https://github.com/loadster/loadster-dashboard/pull/44) 

All `webRequest` listeners are applied after creating a new tab (with the URL provided). They also have an additional filter `tabId`, so we only listen for changes on this particular tab and its children.

Please let me know your thoughts on these:
- The new tab is the only place (in current recording session) from where we can get something. I feel that we need a more clear way to point user on that. Notifications/blinking? Maybe something similar to `scenario`?
- We are currently unable to track the new tabs created _from inside_. 
For example, `target="_blank"`. When you said "that tab or its children" did you mean the new tabs as well?