### PR TITLE
V27.1.0 - Launch incognito tab for recording

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
       - '**'
@@ -25,10 +22,10 @@ jobs:
         run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
       - name: Zip Chrome extension
         working-directory: dist/chrome
-        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-chrome.zip" . -x '.*' '*.map'
+        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-chrome.zip" * -x '.*' '*.map'
       - name: Zip Firefox extension
         working-directory: dist/firefox
-        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-firefox.zip" . -x '.*' '*.map'
+        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-firefox.zip" * -x '.*' '*.map'
       - name: Upload Chrome extension
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm install --no-save @rollup/rollup-linux-x64-gnu
       - run: npm run build
       - name: Get version
         id: version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,17 @@ jobs:
       - name: Get version
         id: version
         run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
-      - name: Zip Chrome extension
-        working-directory: dist/chrome
-        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-chrome.zip" * -x '.*' '*.map'
-      - name: Zip Firefox extension
-        working-directory: dist/firefox
-        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-firefox.zip" * -x '.*' '*.map'
+      - name: Clean build artifacts
+        run: find dist -name '.*' -o -name '*.map' | xargs rm -f
       - name: Upload Chrome extension
         uses: actions/upload-artifact@v4
         with:
           name: loadster-extension-${{ steps.version.outputs.version }}-chrome
-          path: loadster-extension-${{ steps.version.outputs.version }}-chrome.zip
+          path: dist/chrome/*
           retention-days: 7
       - name: Upload Firefox extension
         uses: actions/upload-artifact@v4
         with:
           name: loadster-extension-${{ steps.version.outputs.version }}-firefox
-          path: loadster-extension-${{ steps.version.outputs.version }}-firefox.zip
+          path: dist/firefox/*
           retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+      - name: Zip Chrome extension
+        working-directory: dist/chrome
+        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-chrome.zip" . -x '.*' '*.map'
+      - name: Zip Firefox extension
+        working-directory: dist/firefox
+        run: zip -r "../../loadster-extension-${{ steps.version.outputs.version }}-firefox.zip" . -x '.*' '*.map'
+      - name: Upload Chrome extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: loadster-extension-${{ steps.version.outputs.version }}-chrome
+          path: loadster-extension-${{ steps.version.outputs.version }}-chrome.zip
+          retention-days: 7
+      - name: Upload Firefox extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: loadster-extension-${{ steps.version.outputs.version }}-firefox
+          path: loadster-extension-${{ steps.version.outputs.version }}-firefox.zip
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Loadster Recorder Extension",
   "type": "module",
-  "version": "27.0.1",
+  "version": "27.1.0",
   "description": "Create test scripts to run in Loadster.",
   "scripts": {
     "dev": "vite dev",

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,13 +18,22 @@ export default defineConfig({
         // Use `readJsonFile` instead of import/require to avoid caching during rebuild.
         const pkg = readJsonFile('package.json');
         const template = readJsonFile(target === 'chrome' ? 'manifest.chrome.json' : 'manifest.firefox.json');
-
-        return {
+        const manifest = {
           ...template,
           version: pkg.version,
           name: pkg.name,
           description: pkg.description,
         };
+
+        if (target === 'firefox') {
+          manifest.browser_specific_settings = {
+            "gecko": {
+              "id": "loadster-recorder-extension@loadster-recorder-extension"
+            }
+          };
+        }
+
+        return manifest;
       },
       additionalInputs: [
         'src/contentTab.js',

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,7 +28,7 @@ export default defineConfig({
         if (target === 'firefox') {
           manifest.browser_specific_settings = {
             "gecko": {
-              "id": "loadster-recorder-extension@loadster-recorder-extension"
+              "id": "{f03c369b-ec55-4eac-97cd-79f775e60320}"
             }
           };
         }


### PR DESCRIPTION
This adds support for recording in incognito mode, reducing noise from previous logins, cookies, and other extensions. 
For this to work properly, the extension must be allowed to run in incognito mode. We cannot request this permission programmatically. Therefore, the user must follow the browser's instructions and grant permission manually.
Without permission, the incognito tab will not be created, and recording will begin as usual. No additional action is required.